### PR TITLE
Completions API for OpenAI

### DIFF
--- a/client.go
+++ b/client.go
@@ -156,3 +156,56 @@ func (c *Client) CreateImageVariation(ctx context.Context, imgVarReq *ImageVaria
 func (c *Client) CreateImageEidt(ctx context.Context, imgEditReq *ImageEditRequest) (ImageResponse, error) {
 	return c.CreateImage(ctx, imgEditReq)
 }
+
+func (c *Client) CreateCompletionArr(
+	ctx context.Context,
+	compReq *CompletionRequest[[]string],
+) (CompletionResponse, error) {
+	var compRes CompletionResponse
+	req, err := compReq.GenerateHTTPRequest(ctx)
+	if err != nil {
+		return compRes, err
+	}
+
+	res, err := c.httpClient.Do(c.setHeaders(req))
+	if err != nil {
+		return compRes, err
+	}
+	if err = checkResponse(res); err != nil {
+		return compRes, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return compRes, err
+	}
+	if err = json.Unmarshal(body, &compRes); err != nil {
+		return compRes, err
+	}
+	return compRes, nil
+}
+
+func (c *Client) CreateCompletion(ctx context.Context, compReq *CompletionRequest[string]) (CompletionResponse, error) {
+	var compRes CompletionResponse
+	req, err := compReq.GenerateHTTPRequest(ctx)
+	if err != nil {
+		return compRes, err
+	}
+
+	res, err := c.httpClient.Do(c.setHeaders(req))
+	if err != nil {
+		return compRes, err
+	}
+	if err = checkResponse(res); err != nil {
+		return compRes, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return compRes, err
+	}
+	if err = json.Unmarshal(body, &compRes); err != nil {
+		return compRes, err
+	}
+	return compRes, nil
+}

--- a/completions.go
+++ b/completions.go
@@ -1,0 +1,36 @@
+package openai
+
+type CompletionRequest[T string | []string] struct {
+	LogitBias        map[string]int16 `json:"logit_bias,omitempty"`
+	Model            string           `json:"model"`
+	Prompt           T                `json:"prompt"`
+	Suffix           string           `json:"suffix,omitempty"`
+	Stop             T                `json:"stop,omitempty"`
+	User             string           `json:"user,omitempty"`
+	Temperature      float32          `json:"temperature"`
+	TopP             float32          `json:"top_p"`
+	FrequencePenalty float32          `json:"frequency_penalty"`
+	PresencePenalty  float32          `json:"presence_penalty"`
+	MaxTokens        uint8            `json:"max_tokens"`
+	Logprobs         uint8            `json:"logprobs,omitempty"`
+	N                uint8            `json:"n"`
+	BestOf           uint8            `json:"best_of"`
+	Stream           bool             `json:"stream"`
+	Echo             bool             `json:"echo"`
+}
+
+type ChoiceResponse struct {
+	Index        uint16   `json:"index"`
+	Text         string   `json:"text"`
+	Logprobs     []string `json:"logprobs,omitempty"`
+	FinishReason string   `json:"finish_reason"`
+}
+
+type CompletionResponse struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Created int              `json:"created"`
+	Model   string           `json:"model"`
+	Choices []ChoiceResponse `json:"choices"`
+	Usage   Usage            `json:"usage"`
+}

--- a/completions.go
+++ b/completions.go
@@ -1,5 +1,13 @@
 package openai
 
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
 type CompletionRequest[T string | []string] struct {
 	LogitBias        map[string]int16 `json:"logit_bias,omitempty"`
 	Model            string           `json:"model"`
@@ -33,4 +41,20 @@ type CompletionResponse struct {
 	Model   string           `json:"model"`
 	Choices []ChoiceResponse `json:"choices"`
 	Usage   Usage            `json:"usage"`
+}
+
+// Generates the correct http.Request object for the given API Request Struct.
+func (cr *CompletionRequest[T]) GenerateHTTPRequest(ctx context.Context) (response *http.Request, err error) {
+	reqBytes, err := json.Marshal(cr)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", apiURL, "/completions")
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	return req, nil
 }

--- a/requestbuilder_test.go
+++ b/requestbuilder_test.go
@@ -365,6 +365,23 @@ func TestClient_GetRequestBuilder(t *testing.T) {
 				MaskPath:  "",
 			},
 		},
+		{
+			name: "Get CompletionRequestBuilder Struct",
+			args: args{builder: "completion"},
+			want: CompletionRequestBuilder[string]{
+				Req: &CompletionRequest[string]{
+					Model:            "text-davinci-002",
+					Prompt:           "<|endoftext|>",
+					MaxTokens:        MaxTokensDefault,
+					TopP:             1,
+					N:                1,
+					Stream:           false,
+					Echo:             false,
+					PresencePenalty:  0,
+					FrequencePenalty: 0,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/usage.go
+++ b/usage.go
@@ -1,0 +1,7 @@
+package openai
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_token,omitempty"`
+	CompletionTokens int `json:"completion_tokens,omitempty"`
+	TotalTokens      int `json:"total_tokens"`
+}


### PR DESCRIPTION
This PR aims for the following:
- To implement the openAI Completions API
- Expand the RequestBuilder to help build out those type of requests
- Use Generics to cover the two different type of use cases
- 